### PR TITLE
Return validity in onChange for Textfields

### DIFF
--- a/lib/Textfield.js
+++ b/lib/Textfield.js
@@ -41,7 +41,7 @@ var Textfield = (function (_MDL$UpgradedComponent) {
     _MDL$UpgradedComponent.apply(this, arguments);
 
     this._handleChange = function (e) {
-      _this.props.onChange(e.target.value);
+      _this.props.onChange(e.target.value, e.target.validity.valid);
     };
   }
 

--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -49,7 +49,7 @@ class Textfield extends MDL.UpgradedComponent {
   }
 
   _handleChange = (e) => {
-    this.props.onChange(e.target.value);
+    this.props.onChange(e.target.value, e.target.validity.valid);
   }
 
   render() {


### PR DESCRIPTION
This was the simplest way to do it adding in a 'onValidation' method to the props and then calling it in the componentDidUpdate was causing problems.